### PR TITLE
Remove space and colon in var name `temp_folder` to support Windows 

### DIFF
--- a/R/flamingo_main.R
+++ b/R/flamingo_main.R
@@ -52,7 +52,7 @@ flamingo_main <- function(hic_data,
   # source('assemble_structure.R')
 
   #### create temp folder
-  temp_folder = paste('temp',Sys.time())
+  temp_folder = paste0('temp_',format(Sys.time(), "%Y-%m-%d_%H-%M-%S"))
   dir.create(temp_folder)
   dir.create(paste0(temp_folder,'/domain_data'))
   # dir.create(paste0(temp_folder,'/genomic_loc'))


### PR DESCRIPTION
Otherwise, encounter the following error:

```r
Error in file(file, ifelse(append, "a", "w")) : 
  cannot open the connection
In addition: Warning messages:
1: In dir.create(temp_folder) :
  cannot create dir 'temp 2024-05-07 10:37:57.829779', reason 'Invalid argument'
2: In dir.create(paste0(temp_folder, "/domain_data")) :
  cannot create dir 'temp 2024-05-07 10:37:57.829779\domain_data', reason 'Invalid argument'
3: In file(file, ifelse(append, "a", "w")) :
  cannot open file 'temp 2024-05-07 10:37:57.829779/domain_data/IF_domain_6.txt': Invalid argument
```


